### PR TITLE
move `easeOut` reference and remove parens

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -58,10 +58,10 @@ main {
 
     a {
       padding: 0.4rem;
+      @include easeOut;
 
       &:hover {
         color: $secondary-color;
-        @include easeOut();
       }
     }
   }


### PR DESCRIPTION
Moving the easeOut reference to the link, so the transition applies both to the on and off focus to match the behavior of the menu links (instead of just the on hover, currently). 

Also removing the parens.